### PR TITLE
BUGFIX: Starting agent incorrectly

### DIFF
--- a/tasks/install_agent.yml
+++ b/tasks/install_agent.yml
@@ -13,4 +13,5 @@
   - name: Start the AlertLogic Agent service
     service: name=al-agent state=started enabled=yes
     tags: install_al_agent
+    when: not al_agent_for_imaging
 

--- a/tasks/provision_agent.yml
+++ b/tasks/provision_agent.yml
@@ -14,7 +14,7 @@
   tags: provision_al_agent
   when: not al_agent_for_imaging and agent_provisioned.stat.exists == false and al_agent_provision_options != "[]"
 
-- name: Provision AlertLogic Agent
+- name: Provision AlertLogic Agent - for Imaging
   command: "/etc/init.d/al-agent provision {{ al_agent_provision_options|join(' ') }}"
   tags: provision_al_agent
   when: al_agent_for_imaging and agent_provisioned.stat.exists == false and al_agent_provision_options != "[]"


### PR DESCRIPTION
BUGFIX: To clarify which one is imaging only and which one will register the agent. Skip starting on install