### PR TITLE
Fix rsyslog detection on CentOS 7

### DIFF
--- a/tasks/configure_loggers.yml
+++ b/tasks/configure_loggers.yml
@@ -1,5 +1,5 @@
 - name: Test for rsyslog being installed
-  command: "ls /etc/init.d/rsyslog"
+  command: "ls /etc/rsyslog.conf"
   ignore_errors: True
   register: rsyslog_init_exists
   tags: rsyslog


### PR DESCRIPTION
Previously used file no longer exists (on CentOS 7) and rsyslog changes are never applied.

That change should be compatible with other distributions, but don't have any Debian/Ubuntu server instance to verify it.


Probably similar change would be useful also for syslog-ng. Looking at https://centos.pkgs.org/7/epel-x86_64/syslog-ng-3.5.6-3.el7.x86_64.rpm.html `/etc/syslog-ng/syslog-ng.conf` should be fine. However, I don't use it, not to mention checking the compatibility with other platforms.