### PR TITLE
Misc. fixes/updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Available variables are listed below, along with default values:
     al_agent_egress_port: '' # Optional
     al_agent_egress_host: '' # Optional
     al_agent_proxy_url: '' # Optional
-    al_agent_for_autoscaling: True/False # Default is False
     al_agent_for_imaging: True/False # Default is False
 
 ## Dependencies

--- a/tasks/_rsyslog.yml
+++ b/tasks/_rsyslog.yml
@@ -3,5 +3,4 @@
     - restart rsyslog
   tags: rsyslog
   template: src=templates/etc/rsyslog/alertlogic.conf dest=/etc/rsyslog.d/alertlogic.conf owner=root group=root mode=0644
-  when: rsyslog_init_exists|success
-
+  when: rsyslog_init_exists is success

--- a/tasks/_syslog_ng.yml
+++ b/tasks/_syslog_ng.yml
@@ -3,11 +3,11 @@
   notify:
     - reload syslog-ng
   tags: syslog_ng
-  when: syslog_ng_init_exists|success
+  when: syslog_ng_init_exists is success
 
 - name: Ensure alertlogic.conf file is in place for syslog-ng
   notify:
     - reload syslog-ng
   tags: syslog_ng
   template: src=templates/syslog-ng/alertlogic.conf dest=/etc/syslog-ng/conf.d/alertlogic.conf owner=root group=root mode=0644
-  when: syslog_ng_init_exists|success
+  when: syslog_ng_init_exists is success

--- a/tasks/_windows.yml
+++ b/tasks/_windows.yml
@@ -35,9 +35,6 @@
 - debug: var=al_agent_windows
 
 - name: Install AlertLogic Agent
-  win_msi:
+  win_package:
     path: 'C:\TEMP\al_agent-LATEST.msi'
-    creates: 'C:\Program Files (x86)\AlertLogic'
-    wait: True
-    # Not working if more than one argument is passed, https://github.com/ansible/ansible-modules-core/issues/1229
-    extra_args: "{{ al_agent_windows }}"
+    arguments: "{{ al_agent_windows }}"

--- a/tasks/deb-packages.yml
+++ b/tasks/deb-packages.yml
@@ -12,9 +12,9 @@
 
 - name: download deb packages from the web
   tags: deb-packages
-  get_url: url={{ item.item.url }} dest=/tmp/{{ item.item.name }}.deb force=no
+  get_url: url={{ item.item.url }} dest=/tmp/{{ item.item.name }}.deb force=no timeout=300
   with_items: "{{ deb_packages_status.results }}"
-  when: item.stdout|int == 1 
+  when: item.stdout|int == 1
 
 - name: install downloaded deb packages
   tags: deb-packages

--- a/tasks/provision_agent.yml
+++ b/tasks/provision_agent.yml
@@ -4,9 +4,6 @@
 - set_fact: al_agent_provision_options="{{ al_agent_provision_options }} + [ \'--key \' + al_agent_registration_key ]"
   when: al_agent_registration_key is defined and al_agent_registration_key != "your_registration_key_here"
 
-- set_fact: al_agent_provision_options="{{ al_agent_provision_options }} + [ \'--inst-type host\']"
-  when: al_agent_for_autoscaling
-
 - name: Provision AlertLogic Agent
   command: "/etc/init.d/al-agent provision {{ al_agent_provision_options|join(' ') }}"
   notify:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,5 +5,4 @@
 #al_agent_egress_port: ''
 #al_agent_egress_host: ''
 #al_agent_proxy_url: ''
-al_agent_for_autoscaling: False
 al_agent_for_imaging: False


### PR DESCRIPTION
1. removed references to role mode using the `al_agent_for_autoscaling` variable
2. fixed deprecated warnings related to:
      - Using tests as filters. Instead of using `result|success` use `result is success`
      - Using `win_package` instead for windows installation. `win_msi` is kept for backwards compatibility but will be deprecated in Ansible v2.3.
3. increased deb package download timeout to close #22