### PR TITLE
Add ubuntu 18.04 under the supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-Ansible Role: al-agents
-=======================
+# Ansible Role: al-agents
+
 This playbook is used to install and configure the Alert Logic agent.
 
-Requirements
-------------
+## Requirements
+
 The following platforms are supported.
 
 Debian versions:
@@ -11,45 +11,46 @@ Debian versions:
 * squeeze
 * wheezy
 * jessie
-        
+
 Ubuntu versions:
 
 * 10.x
 * 12.x
 * 14.x
 * 16.x
+* 18.x
 
 RHEL/CentOS versions:
 
 * 6.x
 * 7.x
-        
+
 SuSE versions:
 
- * 12.1
- * 12.0
- * 11.4
- * 11.3
-        
+* 12.1
+* 12.0
+* 11.4
+* 11.3
+
 Amazon Linux versions:
 
 * Karoo
-        
+
 Windows versions:
 
 * Windows Server 2003+SP1, 2008, 2012, 2016
 * Windows XP+SP1, Vista, 7, 8, 10
-       
+
 ## Role Variables
 
 * `al_agent_registration_key` - your unique registration key, required except in supported cloud deployments (AWS, Azure) String defaults to `your_registration_key_here`
 * `al_agent_for_imaging` - The `al_agent_for_imaging` variable determines if the agent will be configured and provisioned.  If  set to `true` then the install process performs an installation of the agent but will not start the agent once installation is completed.  This allows for instance snapshots to be saved and started for later use.  With this variables set to `false` then the provisioning process is performed during setup and the agent is started once complete.  Boolean defaults to `false`
-* `al_agent_egress_host`,`al_agent_egress_port` - By default all traffic is sent to https://vaporator.alertlogic.com.  This variable is useful if you have a machine that is responsible for outbound traffic (NAT box).  If you specify your own URL ensure that it is a properly formatted URI.  String defaults to `https://vaporator.alertlogic.com`
+* `al_agent_egress_host`,`al_agent_egress_port` - By default all traffic is sent to <https://vaporator.alertlogic.com.>  This variable is useful if you have a machine that is responsible for outbound traffic (NAT box).  If you specify your own URL ensure that it is a properly formatted URI.  String defaults to `https://vaporator.alertlogic.com`
 * `al_agent_proxy_url` - By default al-agent does not require the use of a proxy.  This variable is useful if you want to avoid a single point of egress.  When a proxy is used, both `al_agent_egress_host` and `al_agent_proxy_url` values are required.  If you specify a proxy URL ensure that it is a properly formatted URI.  String defaults to `nil`
 
 ## Dependencies
 
-- no known dependancies
+* no known dependancies
 
 ## Example Playbook
 
@@ -59,15 +60,13 @@ Windows versions:
       roles:
         - { role: alertlogic.al_agents}
 
+## Configurations
 
-Configurations
---------------
 The variable `al_agent_for_imaging` determine your installation type.  It is a boolean value and by default is `false`.  Setting this value to true will prepare your agent for imaging only and will not provision the agent.
 
 Performing an agent install using the cookbook's default attributes, will setup the agent and provision the instance immediately. If you have properly set your registration key, your host should appear within Alert Logic's Console within 15 minutes. Note: in AWS and Azure deployments the use of the key is optional and in general not necessary.
 
-Contributing
-------------
+## Contributing
 
 1. Fork the repository on Github
 2. Create a named feature branch (like `add_component_x`)
@@ -76,12 +75,12 @@ Contributing
 5. Run the tests, ensuring they all pass
 6. Submit a Pull Request using Github
 
-License and Authors
--------------------
+## License and Authors
+
 License:
 
 Distributed under the Apache 2.0 license.
 
-Authors: 
+Authors:
 Muram Mohamed (mmohamed@alertlogic.com)
 Justin Early (jearly@alertlogi.com)


### PR DESCRIPTION
Tested and validated.

```log
ansible-playbook 2.9.6
  config file = /Users/muram/Projects/ansible/ansible.cfg
  configured module search path = ['/Users/muram/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.9.6_1/libexec/lib/python3.8/site-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 3.8.2 (default, Mar 11 2020, 00:29:50) [Clang 11.0.0 (clang-1100.0.33.17)]

PLAYBOOK: al-agent.yml *************************************************************************************************************************************************************************************************************
1 plays in al-agent.yml

TASK [Gathering Facts] *************************************************************************************************************************************************************************************************************
ok: [i-009cd54f56aad2a96]

TASK [al-agents-ansible-playbooks : debug] *****************************************************************************************************************************************************************************************
ok: [i-009cd54f56aad2a96] => {
    "msg": "Ubuntu"
}

TASK [al-agents-ansible-playbooks : debug] *****************************************************************************************************************************************************************************************
ok: [i-009cd54f56aad2a96] => {
    "msg": "18"
}

TASK [al-agents-ansible-playbooks : debug] *****************************************************************************************************************************************************************************************
ok: [i-009cd54f56aad2a96] => {
    "msg": "18.04"
}

TASK [al-agents-ansible-playbooks : Include Ansible OS family variables] ***********************************************************************************************************************************************************
task path: /Users/muram/Projects/ansible/roles/al-agents-ansible-playbooks/tasks/_linux.yml:2
ok: [i-009cd54f56aad2a96] => {
    "ansible_facts": {
        "al_agent_base_url": "https://scc.alertlogic.net",
        "al_agent_initscript": "rsyslog",
        "al_agent_pkg_name_arch": "{{ ( ansible_architecture == 'x86_64' ) | ternary('amd64', ansible_architecture) }}",
        "al_agent_pkg_name_ext": "deb",
        "al_agent_pkg_name_prefix": "al-agent_LATEST_",
        "al_agent_pkg_url": "{{ al_agent_base_url }}/software/{{ al_agent_pkg_name_prefix }}{{al_agent_pkg_name_arch}}.{{al_agent_pkg_name_ext}}",
        "al_agent_syslog_ng_source": "{{ ( ansible_distribution_major_version >= '7' ) | ternary('s_all', 's_sys') }}"
    },
    "ansible_included_var_files": [
        "/Users/muram/Projects/ansible/roles/al-agents-ansible-playbooks/vars/Debian.yml"
    ],
    "changed": false
}

changed: [i-009cd54f56aad2a96] => {
    "changed": true,
    "cmd": [
        "/etc/init.d/al-agent",
        "configure"
    ],
    "delta": "0:00:00.006436",
    "end": "2020-03-20 16:12:35.732724",
    "invocation": {
        "module_args": {
            "_raw_params": "/etc/init.d/al-agent configure ",
            "_uses_shell": false,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true,
            "warn": true
        }
    },
    "rc": 0,
    "start": "2020-03-20 16:12:35.726288",
    "stderr": "Mar 20 16:12:35 2020 al-agent[4338]: ALC00083I [alc_config_unregister] clean up registration artefacts",
    "stderr_lines": [
        "Mar 20 16:12:35 2020 al-agent[4338]: ALC00083I [alc_config_unregister] clean up registration artefacts"
    ],
    "stdout": "*** configuration settings saved ***",
    "stdout_lines": [
        "*** configuration settings saved ***"
    ]
}

changed: [i-009cd54f56aad2a96] => {
    "changed": true,
    "cmd": [
        "/etc/init.d/al-agent",
        "provision",
        "--key",
        "a0b2f55a81a4d4df07ad8ac43455de3f635fb13d5967bb99ca"
    ],
    "delta": "0:00:01.694726",
    "end": "2020-03-20 16:12:40.035189",
    "invocation": {
        "module_args": {
            "_raw_params": "/etc/init.d/al-agent provision --key a0b2f55a81a4d4df07ad8ac43455de3f635fb13d5967bb99ca",
            "_uses_shell": false,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true,
            "warn": true
        }
    },
    "rc": 0,
    "start": "2020-03-20 16:12:38.340463",
    "stderr": "Mar 20 16:12:38 2020 al-agent[4362]: ALC00083I [alc_config_unregister] clean up registration artefacts\nMar 20 16:12:38 2020 al-agent[4362]: ALC00709I [alc_host_detect_type] Local host appears to be in Amazon EC2 environment\nMar 20 16:12:40 2020 al-agent[4362]: ALC00080I [alc_config_provision_host] Fetched host certificate \"/var/alertlogic/etc/host_crt.pem\", \"/var/alertlogic/etc/host_key.pem\"",
    "stderr_lines": [
        "Mar 20 16:12:38 2020 al-agent[4362]: ALC00083I [alc_config_unregister] clean up registration artefacts",
        "Mar 20 16:12:38 2020 al-agent[4362]: ALC00709I [alc_host_detect_type] Local host appears to be in Amazon EC2 environment",
        "Mar 20 16:12:40 2020 al-agent[4362]: ALC00080I [alc_config_provision_host] Fetched host certificate \"/var/alertlogic/etc/host_crt.pem\", \"/var/alertlogic/etc/host_key.pem\""
    ],
    "stdout": "",
    "stdout_lines": []
}


PLAY RECAP *************************************************************************************************************************************************************************************************************************
i-009cd54f56aad2a96        : ok=14   changed=5    unreachable=0    failed=0    skipped=23   rescued=0    ignored=0
```