### PR TITLE
Import gpg key for signed RPM

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,6 +23,8 @@ galaxy_info:
       versions:
         - 6
         - 7
+        - 8
+        - 9
     - name: opensuse
       versions:
         - 12.1

--- a/tasks/install_agent.yml
+++ b/tasks/install_agent.yml
@@ -9,6 +9,13 @@
       until: install_result is success
       when: ansible_os_family == "Debian"
 
+    - name: Import Alert Logic Atlas GPG key.
+      ansible.builtin.rpm_key:
+        key: "{{ al_agent_gpg_key }}"
+        fingerprint: "{{ al_agent_gpg_fingerprint }}"
+        state: present
+      when: ansible_os_family == "RedHat"
+
     - name: Install Alert Logic Agent on CentOS/RHEL/Amazon
       package:
         name: "{{ al_agent_pkg_url }}"
@@ -17,9 +24,7 @@
       register: install_result
       retries: 3
       until: install_result is success
-      when:
-        - ansible_os_family != "Debian"
-        - ansible_os_family != "Suse"
+      when: ansible_os_family == "RedHat"
 
     - name: Install Alert Logic Agent on Suse
       zypper:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -6,3 +6,5 @@ al_agent_syslog_ng_source: "{{ ( ansible_distribution_major_version >= '6' ) | t
 al_agent_base_url: 'https://scc.alertlogic.net'
 al_agent_pkg_name_prefix: 'al-agent-LATEST-1.'
 al_agent_pkg_url: "{{ al_agent_base_url }}/software/{{ al_agent_pkg_name_prefix }}{{al_agent_pkg_name_arch}}.{{al_agent_pkg_name_ext}}"
+al_agent_gpg_key: "{{ al_agent_base_url }}/software/al-agent-pkg-key.asc"
+al_agent_gpg_fingerprint: '9a2a3e9a817127b121b2b2fb00802f0e0186cc36'


### PR DESCRIPTION
Resolves #32 

Thanks to @deekayen for [this commit](https://github.com/deekayen/al-agents-ansible-playbooks/commit/01dce3a587861e452baf2e1a87f8565b4372dc00) which forms the basis of this change.

Since EL 7+ defaults to checking RPM signatures, we need to trust the appropriate key